### PR TITLE
Fixes Record.extract (gpb.hrl)

### DIFF
--- a/lib/protobuf/define_message.ex
+++ b/lib/protobuf/define_message.ex
@@ -4,7 +4,7 @@ defmodule Protobuf.DefineMessage do
   alias Protobuf.Decoder
   alias Protobuf.Encoder
 
-  defrecord :field, Record.extract(:field, from_lib: "gpb/include/gpb.hrl")
+  defrecord :field, Record.extract(:field, from: "../gpb/include/gpb.hrl")
 
   def def_message(name, fields) do
     quote do


### PR DESCRIPTION
Using from_lib produces *\* (RuntimeError) error parsing file gpb/include/gpb.hrl, got: {:error, :enoent}
in Elixir 0.11
